### PR TITLE
Fixed error with query

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,16 +15,16 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
   return new Promise((resolve, reject) => {
     graphql(`
       {
-        allMarkdownRemark {
-          edges {
-            node {
-              fields {
-                slug
-              }
-            }
-          }
-        }
-      }
+        allMarkdownRemark {
+          edges {
+            node {
+              fields {
+                slug
+              }
+            }
+          }
+        }
+      }
     `).then(result => {
       console.log('*****',result,'*****')
     })


### PR DESCRIPTION
## Overview

There was an error with the syntax inside the query, some weird empty space or new line character was copied over. To fix it I just copied the query underneath and let prettier do its job, and then copied it back. 