### PR TITLE
fix for when there are no tags in template

### DIFF
--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -69,7 +69,7 @@ function Banner(props) {
           </div>
           <div className={classes.chipContainer}>
             <Typography className={classes.rightMargin}>Tags:</Typography>
-            { frontmatter.tags.map((tag) =>
+            { frontmatter.tags ? frontmatter.tags.map((tag) =>
               <Chip label={tag} color="primary" className={classes.rightMargin} />
             ) }
           </div>

--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -71,7 +71,7 @@ function Banner(props) {
             <Typography className={classes.rightMargin}>Tags:</Typography>
             { frontmatter.tags ? frontmatter.tags.map((tag) =>
               <Chip label={tag} color="primary" className={classes.rightMargin} />
-            ) }
+            ) : null }
           </div>
         </div>
       ) : (


### PR DESCRIPTION
## Overview

App is failing when there are no tags in the banner in the pattern template when you navigate to a pattern.